### PR TITLE
Stage more files or the pack fails (sometimes)

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -29,6 +29,7 @@ parts:
       mkdir -p ${CRAFT_PART_INSTALL}/etc/grafana
       touch ${CRAFT_PART_INSTALL}/etc/grafana/grafana-config.ini
     stage:
+      - bin/*
       - usr/bin/grafana*
       - conf/
       - etc/grafana


### PR DESCRIPTION
Make sure `*/bin/*` get staged. This worked when testing locally yesterday, but fails on a different machine, and failed the release workflow.