### PR TITLE
add new versions and fix certificates

### DIFF
--- a/10.0.3/rockcraft.yaml
+++ b/10.0.3/rockcraft.yaml
@@ -56,16 +56,16 @@ parts:
     stage:
       - public/
       - tools/
-  ca_certificates:
+  ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil
     after:
       - grafana
       - grafana-ui
-      - ca_certificates
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/10.2.0/rockcraft.yaml
+++ b/10.2.0/rockcraft.yaml
@@ -56,16 +56,16 @@ parts:
     stage:
       - public/
       - tools/
-  ca_certificates:
+  ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil
     after:
       - grafana
       - grafana-ui
-      - ca_certificates
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/10.3.1/rockcraft.yaml
+++ b/10.3.1/rockcraft.yaml
@@ -56,16 +56,16 @@ parts:
     stage:
       - public/
       - tools/
-  ca_certificates:
+  ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil
     after:
       - grafana
       - grafana-ui
-      - ca_certificates
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/

--- a/10.3.3/rockcraft.yaml
+++ b/10.3.3/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: grafana
 summary: Grafana in a ROCK.
 description: "The open and composable observability and data visualization platform. Visualize metrics, logs, and traces from multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB, Postgres and many more."
-version: "10.2.3"
+version: "10.3.3"
 base: ubuntu@22.04
 license: AGPL-3.0
 services:
@@ -15,7 +15,7 @@ parts:
   grafana:
     plugin: go
     source: https://github.com/grafana/grafana.git
-    source-tag: v10.2.3
+    source-tag: v10.3.3
     source-depth: 1
     build-snaps:
       - go/1.21/stable
@@ -36,7 +36,7 @@ parts:
     plugin: nil
     source-type: git
     source: https://github.com/grafana/grafana.git
-    source-tag: v10.2.3
+    source-tag: v10.3.3
     build-snaps:
       - node/18/stable
     build-environment:

--- a/10.4.0/rockcraft.yaml
+++ b/10.4.0/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: grafana
 summary: Grafana in a ROCK.
 description: "The open and composable observability and data visualization platform. Visualize metrics, logs, and traces from multiple sources like Prometheus, Loki, Elasticsearch, InfluxDB, Postgres and many more."
-version: "10.2.3"
+version: "10.4.0"
 base: ubuntu@22.04
 license: AGPL-3.0
 services:
@@ -15,7 +15,7 @@ parts:
   grafana:
     plugin: go
     source: https://github.com/grafana/grafana.git
-    source-tag: v10.2.3
+    source-tag: v10.4.0
     source-depth: 1
     build-snaps:
       - go/1.21/stable
@@ -36,7 +36,7 @@ parts:
     plugin: nil
     source-type: git
     source: https://github.com/grafana/grafana.git
-    source-tag: v10.2.3
+    source-tag: v10.4.0
     build-snaps:
       - node/18/stable
     build-environment:

--- a/9.5.3/rockcraft.yaml
+++ b/9.5.3/rockcraft.yaml
@@ -56,16 +56,16 @@ parts:
     stage:
       - public/
       - tools/
-  ca_certificates:
+  ca-certs:
     plugin: nil
-    stage-packages:
+    overlay-packages:
       - ca-certificates
   deb-security-manifest:
     plugin: nil
     after:
       - grafana
       - grafana-ui
-      - ca_certificates
+      - ca-certs
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/


### PR DESCRIPTION
## Issue
Currently, the `ca-certificates` package is added to the rock, but it's missing the default certificates in `/etc/ssl/certs`.

This happens not because we don't stage them, but because `stage-packages: [ca-certificates]` doesn't run the maintainer scripts that would populate `/etc/ssl/certs`, so that folder stays empty.

## Solution
The solution to this is to change `stage-packages:` to `overlay-packages` in the `ca-certs` part, because that also runs the maintainer scripts and correctly populates the `/ets/ssl/certs` folder.

---

Besides that, this PR also adds new versions that had pending PRs, and renames the build part for consistency with other rocks :)

## Testing Instructions

You can test it yourself by simply running the rock and checking the certs are there via `ls /etc/ssl/certs`.

```bash
root@8f0199aebc08:/# which update-ca-certificates
/usr/sbin/update-ca-certificates
root@8f0199aebc08:/# ll /etc/ssl/certs/
total 604
```