### PR TITLE
feat: build 9.5.21 from commit to include CVE fix

### DIFF
--- a/9.5.21/rockcraft.yaml
+++ b/9.5.21/rockcraft.yaml
@@ -15,7 +15,12 @@ parts:
   grafana:
     plugin: go
     source: https://github.com/grafana/grafana.git
-    source-tag: v9.5.21
+    # source-tag: v9.5.21
+    # Version 9.5.21 was tagged on Jul 25, 2024:
+    # https://github.com/grafana/grafana/releases/tag/v9.5.21
+    # But a CVE fix was merged on Aug 14 2024:
+    # https://github.com/grafana/grafana/pull/91927
+    source-commit: 8469ec46776ea6ea5db3e67e970d6735733f78e9
     source-depth: 1
     build-snaps:
       - go/1.21/stable
@@ -36,7 +41,12 @@ parts:
     plugin: nil
     source-type: git
     source: https://github.com/grafana/grafana.git
-    source-tag: v9.5.21
+    # source-tag: v9.5.21
+    # Version 9.5.21 was tagged on Jul 25, 2024:
+    # https://github.com/grafana/grafana/releases/tag/v9.5.21
+    # But a CVE fix was merged on Aug 14 2024:
+    # https://github.com/grafana/grafana/pull/91927
+    source-commit: 8469ec46776ea6ea5db3e67e970d6735733f78e9
     build-snaps:
       - node/18/stable
     build-environment:


### PR DESCRIPTION
## Issue
- v9.5.21 was never released to dockerhub because it failed vuln check [in oci-factory](https://github.com/canonical/oci-factory/pull/354).
- Upstream, a [CVE fix was merged](https://github.com/grafana/grafana/pull/91927) but not tagged. The [9.5.21 tag](https://github.com/grafana/grafana/releases/tag/v9.5.21) is a month earlier.

## Solution
Pack from commit.