### PR TITLE
fix: use updated rock-release-oci-factory workflow

### DIFF
--- a/.github/workflows/release-oci-factory.yaml
+++ b/.github/workflows/release-oci-factory.yaml
@@ -9,5 +9,5 @@ on:
 jobs:
   release-oci-factory:
     name: Release to OCI Factory
-    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@224c92a71bb24f4c67969c331c29b46876178a81
+    uses: canonical/observability/.github/workflows/rock-release-oci-factory.yaml@f3b465e651b8d8d40c82da8104689c3dcc90c8a0
     secrets: inherit


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
The current `rock-release-oci-factory` references an outdated workflow from the central observability CI repo which fails to open a PR into OCI factory for this charm. The PR https://github.com/canonical/observability/pull/433 fixed that. We should reference the commit hash with this change on main.

## Solution
<!-- A summary of the solution addressing the above issue -->


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
